### PR TITLE
Feat: add basket rate to token and daily/hourly snapshots

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -366,8 +366,8 @@ type RToken @entity {
   " Total RSR unStaked (cumulative) "
   totalRsrUnstaked: BigInt!
 
-  " Exchange rate between basket units to totalSupply of rToken "
-  basketRate: BigDecimal!
+  "Basket units of the rToken"
+  basketsNeeded: BigInt!
 
   " holders rewards distribution share "
   holdersRewardShare: BigDecimal!
@@ -459,9 +459,6 @@ type RTokenDailySnapshot @entity {
   " Reward token exchange rate "
   rsrExchangeRate: BigDecimal!
 
-  " Exchange rate between basket units to totalSupply of rToken "
-  basketRate: BigDecimal!
-
   " Daily revenue given to RToken holders "
   dailyRTokenRevenueUSD: BigDecimal!
 
@@ -519,9 +516,6 @@ type RTokenHourlySnapshot @entity {
 
   " Reward token exchange rate "
   rsrExchangeRate: BigDecimal!
-
-  " Exchange rate between basket units to totalSupply of rToken "
-  basketRate: BigDecimal!
 
   " Daily revenue given to RToken holders "
   hourlyRTokenRevenueUSD: BigDecimal!
@@ -653,6 +647,9 @@ type Token @entity {
   " USD Price "
   lastPriceUSD: BigDecimal!
 
+  " Exchange rate between basket units to totalSupply of rToken "
+  basketRate: BigDecimal!
+
   " Optional field to track the block number of the last token price "
   lastPriceBlockNumber: BigInt!
 
@@ -746,6 +743,9 @@ type TokenDailySnapshot @entity {
   " USD Price "
   priceUSD: BigDecimal!
 
+  " Exchange rate between basket units to totalSupply of rToken "
+  basketRate: BigDecimal!
+
   " Block number of this snapshot "
   blockNumber: BigInt!
 
@@ -792,6 +792,9 @@ type TokenHourlySnapshot @entity {
 
   " USD Price "
   priceUSD: BigDecimal!
+
+  " Exchange rate between basket units to totalSupply of rToken "
+  basketRate: BigDecimal!
 
   " Block number of this snapshot "
   blockNumber: BigInt!

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -246,7 +246,6 @@ export function getOrCreateRTokenDailySnapshot(
     rTokenMetrics.dailyRSRUnstaked = BIGINT_ZERO;
     rTokenMetrics.cumulativeRSRUnstaked = BIGINT_ZERO;
     rTokenMetrics.rsrExchangeRate = BIGDECIMAL_ZERO;
-    rTokenMetrics.basketRate = BIGDECIMAL_ZERO;
     rTokenMetrics.dailyRTokenRevenueUSD = BIGDECIMAL_ZERO;
     rTokenMetrics.cumulativeRTokenRevenueUSD = BIGDECIMAL_ZERO;
     rTokenMetrics.dailyRSRRevenueUSD = BIGDECIMAL_ZERO;
@@ -287,7 +286,6 @@ export function getOrCreateRTokenHourlySnapshot(
     rTokenMetrics.hourlyRSRUnstaked = BIGINT_ZERO;
     rTokenMetrics.cumulativeRSRUnstaked = BIGINT_ZERO;
     rTokenMetrics.rsrExchangeRate = BIGDECIMAL_ZERO;
-    rTokenMetrics.basketRate = BIGDECIMAL_ZERO;
     rTokenMetrics.hourlyRTokenRevenueUSD = BIGDECIMAL_ZERO;
     rTokenMetrics.cumulativeRTokenRevenueUSD = BIGDECIMAL_ZERO;
     rTokenMetrics.hourlyRSRRevenueUSD = BIGDECIMAL_ZERO;
@@ -318,6 +316,7 @@ export function getOrCreateToken(tokenAddress: Address): Token {
     token.cumulativeVolume = BIGINT_ZERO;
     token.lastPriceBlockNumber = BIGINT_ZERO;
     token.lastPriceUSD = BIGDECIMAL_ZERO;
+    token.basketRate = BIGDECIMAL_ZERO;
 
     // Inherit RSVmetrics
     if (tokenAddress.equals(RSV_ADDRESS)) {
@@ -383,6 +382,7 @@ export function getOrCreateTokenDailySnapshot(
     tokenMetrics.dailyBurnAmount = BIGINT_ZERO;
     tokenMetrics.dailyVolume = BIGINT_ZERO;
     tokenMetrics.priceUSD = BIGDECIMAL_ZERO;
+    tokenMetrics.basketRate = BIGDECIMAL_ZERO;
     tokenMetrics.blockNumber = event.block.number;
     tokenMetrics.timestamp = event.block.timestamp;
 
@@ -417,6 +417,7 @@ export function getOrCreateTokenHourlySnapshot(
     tokenMetrics.hourlyBurnCount = INT_ZERO;
     tokenMetrics.hourlyBurnAmount = BIGINT_ZERO;
     tokenMetrics.priceUSD = BIGDECIMAL_ZERO;
+    tokenMetrics.basketRate = BIGDECIMAL_ZERO;
     tokenMetrics.hourlyVolume = BIGINT_ZERO;
     tokenMetrics.blockNumber = event.block.number;
     tokenMetrics.timestamp = event.block.timestamp;

--- a/src/mappings/deployer.ts
+++ b/src/mappings/deployer.ts
@@ -90,7 +90,7 @@ export function handleCreateToken(event: RTokenCreated): void {
   rToken.rsrStaked = BIGINT_ZERO;
   rToken.totalRsrStaked = BIGINT_ZERO;
   rToken.totalRsrUnstaked = BIGINT_ZERO;
-  rToken.basketRate = BIGDECIMAL_ONE;
+  rToken.basketsNeeded = BIGINT_ZERO;
   rToken.backing = BIGINT_ZERO;
   rToken.backingRSR = BIGINT_ZERO;
   rToken.stakersRewardShare = BIGDECIMAL_ZERO;


### PR DESCRIPTION
This is to achieve "Show ETH+ price in ETH terms" for historical price chart
Playground: https://subgraph.satsuma-prod.com/reserve/reserve-mainnet-test/version/v0.0.5/playground
Query:
```
{
  rtokens (where: {id: "0xe72b141df173b999ae7c1adcbf60cc9833ce56a8"}) {
    id
    basketsNeeded
    token {
      name
      totalSupply
      basketRate
    }
  }
  tokenDailySnapshots (
    where: {token: "0xe72b141df173b999ae7c1adcbf60cc9833ce56a8"}
    orderBy: timestamp
    orderDirection: desc
  ) {
    id
    priceUSD
    basketRate
    timestamp
  }
}
```