### PR TITLE
Add rToken.rsrLocked property to correct staking APY

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -357,7 +357,10 @@ type RToken @entity {
   " Exchange rate on big int for internal calculations "
   rawRsrExchangeRate: BigInt!
 
-  " How much RSR is currently locked in this RToken "
+  " How much RSR is currently locked in this RToken (earning rewards) "
+  rsrLocked: BigInt!
+
+  " How much RSR is currently pooled in this RToken (overcollateralization) "
   rsrStaked: BigInt!
 
   " Total RSR staked (cumulative) "

--- a/src/common/metrics.ts
+++ b/src/common/metrics.ts
@@ -209,6 +209,7 @@ export function updateRTokenMetrics(
 
     // rToken
     rToken.rsrStaked = rToken.rsrStaked.plus(amount);
+    rToken.rsrLocked = rToken.rsrLocked.plus(amount);
     rToken.totalRsrStaked = rToken.totalRsrStaked.plus(amount);
   } else if (entryType === EntryType.UNSTAKE) {
     protocol.totalRsrUnstaked = protocol.totalRsrUnstaked.plus(amount);
@@ -218,6 +219,7 @@ export function updateRTokenMetrics(
     );
 
     // rToken
+    rToken.rsrLocked = rToken.rsrLocked.minus(amount);
     rToken.totalRsrUnstaked = rToken.totalRsrUnstaked.plus(amount);
   } else if (
     entryType === EntryType.WITHDRAW ||
@@ -314,7 +316,9 @@ export function updateTokenMetrics(
     if (newSupply.equals(BIGINT_ZERO)) {
       token.basketRate = BIGDECIMAL_ZERO;
     } else {
-      token.basketRate = token.basketRate.times(token.totalSupply.toBigDecimal()).div(newSupply.toBigDecimal());
+      token.basketRate = token.basketRate
+        .times(token.totalSupply.toBigDecimal())
+        .div(newSupply.toBigDecimal());
     }
     // Daily
     tokenDaily.dailyMintCount += INT_ONE;
@@ -331,7 +335,9 @@ export function updateTokenMetrics(
     if (newSupply.equals(BIGINT_ZERO)) {
       token.basketRate = BIGDECIMAL_ZERO;
     } else {
-      token.basketRate = token.basketRate.times(token.totalSupply.toBigDecimal()).div(newSupply.toBigDecimal());
+      token.basketRate = token.basketRate
+        .times(token.totalSupply.toBigDecimal())
+        .div(newSupply.toBigDecimal());
     }
     // Daily
     tokenDaily.dailyBurnCount += INT_ONE;
@@ -342,7 +348,7 @@ export function updateTokenMetrics(
     tokenHourly.hourlyBurnAmount = tokenHourly.hourlyBurnAmount.plus(amount);
     tokenHourly.basketRate = token.basketRate;
   }
-  
+
   token.totalSupply = newSupply;
   token.cumulativeVolume = token.cumulativeVolume.plus(amount);
   token.transferCount = token.transferCount.plus(BIGINT_ONE);

--- a/src/mappings/deployer.ts
+++ b/src/mappings/deployer.ts
@@ -88,6 +88,7 @@ export function handleCreateToken(event: RTokenCreated): void {
   rToken.rewardTokenSupply = BIGINT_ZERO;
   rToken.rsrExchangeRate = BIGDECIMAL_ONE;
   rToken.rsrStaked = BIGINT_ZERO;
+  rToken.rsrLocked = BIGINT_ZERO;
   rToken.totalRsrStaked = BIGINT_ZERO;
   rToken.totalRsrUnstaked = BIGINT_ZERO;
   rToken.basketsNeeded = BIGINT_ZERO;


### PR DESCRIPTION
Currently, there is a discrepancy between an RToken page's stRSR yield, and on the Overview page:

![image](https://github.com/reserve-protocol/reserve-subgraph/assets/71284258/75e62f63-1f47-49a0-a944-d6f5cf8e542f)
![image](https://github.com/reserve-protocol/reserve-subgraph/assets/71284258/a6541e24-7c9c-475d-96f2-2a4710aab103)

The former is correct because it takes into account only the RSR that still exists as stRSR (i.e. not pending unstake) in the rewards calculation. This PR adds a new property `rToken.rsrLocked` which exposes the actual reward earning stakes from which we calculate APY.

This line to be changed in Register to complete the fix: https://github.com/reserve-protocol/register/blob/master/src/hooks/useTokenList.tsx#L139